### PR TITLE
OkHttp 3.0.1 -> 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.0.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>3.0.1</version>
+      <version>3.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
New version. The integration tests are failing locally (java.lang.NoClassDefFoundError: com/google/gson/JsonParseException) but this happened even without the change
