### PR TITLE
Coerce null request bodies to empty

### DIFF
--- a/src/test/java/com/jakewharton/retrofit/Ok3ClientIntegrationTest.java
+++ b/src/test/java/com/jakewharton/retrofit/Ok3ClientIntegrationTest.java
@@ -26,6 +26,7 @@ public final class Ok3ClientIntegrationTest {
   private interface Service {
     @GET("/") Response get();
     @POST("/") Response post(@Body TypedInput body);
+    @POST("/") Response post();
   }
 
   @Before public void setUp() {
@@ -71,5 +72,22 @@ public final class Ok3ClientIntegrationTest {
     assertThat(request.getMethod()).isEqualTo("POST");
     assertThat(request.getPath()).isEqualTo("/");
     assertThat(request.getBody().readUtf8()).isEqualTo("Hello?");
+  }
+
+  @Test public void emptyBody() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse()
+                       .addHeader("Hello", "World")
+                       .setBody("Hello!"));
+
+    Response response = service.post();
+    assertThat(response.getReason()).isEqualTo("OK");
+    assertThat(response.getUrl()).isEqualTo(server.url("/").toString());
+    assertThat(response.getHeaders()).contains(new Header("Hello", "World"));
+    assertThat(buffer(source(response.getBody().in())).readUtf8()).isEqualTo("Hello!");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getMethod()).isEqualTo("POST");
+    assertThat(request.getPath()).isEqualTo("/");
+    assertThat(request.getBody().readUtf8()).isEqualTo("");
   }
 }


### PR DESCRIPTION
Avoids the exception thrown by OkHttp for empty bodies that was fixed in Retrofit 2 here: https://github.com/square/retrofit/commit/19ac1e2c4551448184ad66c4a0ec172e2741c2ee

Dunno if it's a bad idea to reference `HttpMethod#requiresRequestBody` because it's internal...I'd be glad to change it!
